### PR TITLE
Simplify naming by removing "mass" suffix, improve documentation

### DIFF
--- a/src/DeltaQ/Model/DeltaQ.hs
+++ b/src/DeltaQ/Model/DeltaQ.hs
@@ -68,39 +68,56 @@ class ( Fractional (NumericType p)
   never        = fromNumericType 0
   always       = fromNumericType 1
 
--- | ∆Q - a relationship between timeliness and probability that admits the
---   notion of non-occurrence.
-class ( Probability (ProbMass icdf)
+{-| A 'DeltaQ' is an improper probability distribution of time values.
+Here, \"improper\" means that there may be a non-zero probability
+of no value occuring.
+
+Put differently, an instance 'icdf' of the class 'DeltaQ' represents
+a (proper) probability distribution on values of type @'Maybe' ('Time' icdf)@.
+When sampling from this probability distribution,
+we say that drawing a value of the form @'Just' t@ is a __success__,
+while drawing a value of the form 'Nothing' is a __failure__.
+
+For reasons of accuracy or speed, we want to allow different
+implementations on different numeric types, say,
+'Double' or 'Rational'.
+The type family 'Prob' records the type of 'Probability' used,
+and the type family 'Time' records the type of time values used.
+-}
+class ( Probability (Prob icdf)
       , Num (Time icdf) 
       ) => DeltaQ icdf where
-  type ProbMass icdf
-  type Time     icdf
+  type Prob icdf
+  type Time icdf
 
-  -- | Perfection - instantaneous 100% __success__.
+  -- | Perfection — the time value @0@ occurs with 100% probability.
   perfection :: icdf
-  -- | Bottom - never occurs, 100% __failure__.
+  -- | Bottom — with 100% probability, sampling from this distribution
+  -- will result in failure.
   bottom :: icdf
-  -- | cumulative probability mass - the probability that /success/ will have
-  --   occurred at or before the given time.
-  cumulativeMass :: icdf -> Time icdf -> ProbMass icdf
+  -- | Cumulative probiablity mass
+  -- — @cumulativeMass d t@ is the probability that a sample from
+  -- this distribution is a /success/ whose time value is before or equal
+  -- to the given time @t@.
+  cumulativeMass :: icdf -> Time icdf -> Prob icdf
   -- | As above, but only defined over the support.
-  cumulativeMass' :: icdf -> Time icdf -> Maybe (ProbMass icdf)
+  cumulativeMass' :: icdf -> Time icdf -> Maybe (Prob icdf)
   -- | The support. The values of time before (and after) which the cumulative
   --   distribution does not change. The upper bound is present if the support
   --   has a finite upper bound.
   support :: icdf -> (Time icdf, Maybe (Time icdf))
   -- | The limit of the cumulative probability at and beyond the upper bound of
   --   support.
-  tangibleMass :: icdf -> ProbMass icdf
+  tangibleMass :: icdf -> Prob icdf
   -- | The time at which the request probability mass has accumulated.
-  centile :: icdf -> ProbMass icdf -> Maybe (Time icdf)
+  centile :: icdf -> Prob icdf -> Maybe (Time icdf)
 
-  centiles :: icdf -> [ProbMass icdf] -> [Maybe (Time icdf)]
+  centiles :: icdf -> [Prob icdf] -> [Maybe (Time icdf)]
 
   {-# MINIMAL perfection, bottom, (cumulativeMass | cumulativeMass'), support,  tangibleMass, (centile | centiles) #-}
 
   default cumulativeMass :: Ord (Time icdf)
-                         => icdf -> Time icdf -> ProbMass icdf
+                         => icdf -> Time icdf -> Prob icdf
   cumulativeMass icdf t
     | t < l                 = never
     | maybe False (t >) u   = tangibleMass icdf
@@ -110,7 +127,7 @@ class ( Probability (ProbMass icdf)
       err1  = error "cumulativeMass: DeltaQ model error - not defined over support"
 
   default cumulativeMass' :: Ord (Time icdf)
-                          => icdf -> Time icdf -> Maybe (ProbMass icdf)
+                          => icdf -> Time icdf -> Maybe (Prob icdf)
 
   cumulativeMass' icdf t
     | t < l                 = Just $ never
@@ -137,10 +154,10 @@ class (DeltaQ icdf) => DeltaQOps icdf where
   normalise :: icdf -> icdf
 
   -- | Left biased probabilistic choice.
-  choice :: ProbMass icdf -> icdf -> icdf -> icdf
+  choice :: Prob icdf -> icdf -> icdf -> icdf
 
   -- | Given a weighted sequence derive the weighted sum
-  nWayChoice :: [(NumericType (ProbMass icdf), icdf)] -> icdf
+  nWayChoice :: [(NumericType (Prob icdf), icdf)] -> icdf
 
   -- | Sequential composition of two expressions
   convolve :: icdf -> icdf -> icdf

--- a/src/DeltaQ/Model/Introspection.hs
+++ b/src/DeltaQ/Model/Introspection.hs
@@ -8,7 +8,7 @@ module DeltaQ.Model.Introspection
 where
 
 import Data.Maybe (isNothing)
-import DeltaQ.Model.DeltaQ ( ProbabilityMass (..)
+import DeltaQ.Model.DeltaQ ( Probability (..)
                            , DeltaQ (..))
 
 -- | The slack \/ hazard - the difference between the point in time \/
@@ -37,13 +37,13 @@ class (DeltaQ icdf) => DeltaQIntrospection icdf where
   probTimedout icdf to = complement $ cumulativeMass icdf to
 
   pointSlackHazard icdf (t,p)
-    | dp >= 0      = Slack  dt (fromMassModel dp)
+    | dp >= 0      = Slack  dt (fromNumericType dp)
     -- ^ There must exist a non-negative time difference.
-    | isNothing t' = Hazard Nothing (fromMassModel $ negate dp)
+    | isNothing t' = Hazard Nothing (fromNumericType $ negate dp)
     -- ^ There is no upper bound on the time.
-    | otherwise    = Hazard (Just $ negate dt) (fromMassModel $ negate dp)
+    | otherwise    = Hazard (Just $ negate dt) (fromNumericType $ negate dp)
     where
-      dp = toMassModel p' - toMassModel p
+      dp = toNumericType p' - toNumericType p
       dt =  t - (maybe err id t')
 
       t' = centile icdf p

--- a/src/DeltaQ/Model/Introspection.hs
+++ b/src/DeltaQ/Model/Introspection.hs
@@ -4,32 +4,36 @@
 module DeltaQ.Model.Introspection
   ( DeltaQIntrospection (..)
   , Slazard (..)
-  )
-where
+  ) where
 
-import Data.Maybe (isNothing)
-import DeltaQ.Model.DeltaQ ( Probability (..)
-                           , DeltaQ (..))
+import Data.Maybe
+    ( isNothing
+    )
+import DeltaQ.Model.DeltaQ
+    ( DeltaQ (..)
+    , Probability (..)
+    , Prob
+    )
 
 -- | The slack \/ hazard - the difference between the point in time \/
 --  probability mass space and the given `DeltaQ`. `Slack` represents the
 --  reference point being achieved; `Hazard` represents the point not being
 --  achieved a measure of the degree of it being missed.
 data (DeltaQ icdf) => Slazard icdf
-  = Slack (Time icdf) (ProbMass icdf)
+  = Slack (Time icdf) (Prob icdf)
   -- ^ the __slack__. Expressed in terms of both time and probability mass
-  | Hazard (Maybe (Time icdf)) (ProbMass icdf)
+  | Hazard (Maybe (Time icdf)) (Prob icdf)
   -- ^ the __hazard__. Expressed in terms of probability mass and, if waiting
   --   would have worked, time.
 
 -- | Ability to extract internal detail of aspects of the expressions.
 class (DeltaQ icdf) => DeltaQIntrospection icdf where
   -- | Extract the probability that the timeout would occur.
-  probTimedout :: icdf -> Time icdf -> ProbMass icdf
+  probTimedout :: icdf -> Time icdf -> Prob icdf
   -- | Extract the /slack/ (or /hazard/) for a single (time, probability) point
   --   - the degenerative QTA (Quantitative Timeliness Agreement)
   pointSlackHazard :: icdf
-                   -> (Time icdf, ProbMass icdf)
+                   -> (Time icdf, Prob icdf)
                    -> Slazard icdf
 
 -- here? Things that might inform a scheduler, for example

--- a/src/DeltaQ/Model/Utilities.hs
+++ b/src/DeltaQ/Model/Utilities.hs
@@ -4,16 +4,18 @@ module DeltaQ.Model.Utilities
 where
 
 import DeltaQ.Model.DeltaQ
+    ( DeltaQ (..)
+    )
 
 class (DeltaQ irv) => DeltaQVisualisation irv where
   -- | Return a sequence of Time and Probability Mass points of a given length
   --   over the support of the ΔQ. The sequence is monotonitically increasing in
   --   both Time and Probablity Mass.
-  asDiscreteCDF :: irv -> Int -> [(Time irv, ProbMass irv)]
+  asDiscreteCDF :: irv -> Int -> [(Time irv, Prob irv)]
   -- | Return a sequence of (Left) Impulse Probablity mass (equivalent to the
   --   integral of the Heaviside function at that point) or (Right) a sequence
   --   of Time and Probability Density. The sequence is monotonitcally increasing in Time.
-  asDiscretePDF :: irv -> Int -> [Either (Time irv, ProbMass irv) [(Time irv, ProbMass irv)]]
+  asDiscretePDF :: irv -> Int -> [Either (Time irv, Prob irv) [(Time irv, Prob irv)]]
 
 {-
 class (DeltaQ icdf) => DeltaQSupport icdf where


### PR DESCRIPTION
With this pull request, I mainly suggest to simplify the names related to the `ProbabilityMass` class — I think that it's beneficial to remove the suffix "mass" in all places, as it adds more confusion than value. Here I have removed it in the type and class names. I would also suggest to remove it from function names such as `cumulativeMass`, but I have not done so here.

In all circumstances, I believe that using the word "probability" instead of "mass" adds clarity — I understand that we are dealing with improper probability distributions, but the word "probability" has suggestive operational meaning attached to it, whereas "mass" is abstract. Talking about "probability of failure" is evocative, whereas talking about "intangible mass" is not. Put differently: It is not a coincidence that improper probability distributions are rarely written about in the literature, whereas probabilities on a sample space which contains "failure" events are more common.

I have also improved parts of the documentation to be more precise about the meaning of various data types — e.g. what the instances of the type classes are meant to represent, and what the purpose of the type families is.